### PR TITLE
Make crate no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,10 @@ include = [
 ]
 
 [dependencies]
-nom = "5.0.0"
-chrono = "0.4.7"
+nom = { version = "5.1.0", default-features = false }
+chrono = { version = "0.4.7", default-features = false }
+arrayvec = { version = "0.5", default-features = false }
+
+[features]
+default = ["std"]
+std = ["nom/std", "chrono/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,3 @@ include = [
 nom = { version = "5.1.0", default-features = false }
 chrono = { version = "0.4.7", default-features = false }
 arrayvec = { version = "0.5", default-features = false }
-
-[features]
-default = ["std"]
-std = ["nom/std", "chrono/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 description = "An NMEA-0183 sentence parser using nom 5."
 repository = "https://github.com/YellowInnovation/nmea-0183"
 documentation = "https://docs.rs/nmea-0183/"
-keywords = ["nmea", "nmea-0183", "gps", "nom", "parser"]
+keywords = ["nmea", "nmea-0183", "gps", "nom", "parser", "no_std"]
+categories = ["no-std"]
 license = "MIT/Apache-2.0"
 include = [
     "**/*.rs",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # NMEA-0183
-A nmea-0183 sentence parser written in Rust using Nom.
+A nmea-0183 sentence parser written in Rust using Nom. This is a `no_std` crate and can be used in embedded applications.
 
 <p align="center">
   <a href="https://crates.io/crates/nmea-0183">

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ pub enum Error<'a> {
     ParseError(Err<(&'a str, nom::error::ErrorKind)>),
 }
 
-impl<'a> std::convert::From<nom::Err<(&'a str, nom::error::ErrorKind)>> for Error<'a> {
+impl<'a> core::convert::From<nom::Err<(&'a str, nom::error::ErrorKind)>> for Error<'a> {
     fn from(err: nom::Err<(&'a str, nom::error::ErrorKind)>) -> Error<'a> {
         Error::ParseError(err)
     }

--- a/src/fields/identity/parsers.rs
+++ b/src/fields/identity/parsers.rs
@@ -88,9 +88,9 @@ pub fn parse_talker(input: &str) -> IResult<&str, Talker> {
     }
 }
 
-pub fn parse_satellites_in_view(input: &str) -> IResult<&str, Vec<SatelliteInView>> {
+pub fn parse_satellites_in_view(input: &str) -> IResult<&str, SatelliteInViewList> {
     let mut remaining = input;
-    let mut satellites = Vec::new();
+    let mut satellites = SatelliteInViewList::new();
     while remaining.len() != 0 {
         let sv = parse_satellite_in_view(remaining)?;
         remaining = sv.0;

--- a/src/fields/identity/parsers.rs
+++ b/src/fields/identity/parsers.rs
@@ -94,7 +94,9 @@ pub fn parse_satellites_in_view(input: &str) -> IResult<&str, SatelliteInViewLis
     while remaining.len() != 0 {
         let sv = parse_satellite_in_view(remaining)?;
         remaining = sv.0;
-        satellites.push(sv.1);
+        satellites
+            .try_push(sv.1)
+            .map_err(|_| nom::Err::Failure((remaining, nom::error::ErrorKind::TooLarge)))?;
     }
     Ok((remaining, satellites))
 }

--- a/src/fields/identity/structs.rs
+++ b/src/fields/identity/structs.rs
@@ -1,3 +1,5 @@
+use arrayvec::ArrayVec;
+
 use crate::fields::distance::Degree;
 use crate::fields::parameter::DBHZ;
 
@@ -156,3 +158,6 @@ pub struct SatelliteInView {
     /// Signal strength
     pub cno: Option<DBHZ>,
 }
+
+/// List of satellites in view. Maximum of 4 as per GSV definition.
+pub type SatelliteInViewList = ArrayVec<[SatelliteInView; 4]>;

--- a/src/fields/parameter/parsers.rs
+++ b/src/fields/parameter/parsers.rs
@@ -112,7 +112,9 @@ pub fn parse_pos_mode_vec(input: &str) -> IResult<&str, FixList> {
     while pos_modes_str.len() > 0 {
         let res = parse_pos_mode(pos_modes_str)?;
         pos_modes_str = res.0;
-        pos_modes.push(res.1);
+        pos_modes
+            .try_push(res.1)
+            .map_err(|_| nom::Err::Failure((pos_modes_str, nom::error::ErrorKind::TooLarge)))?;
     }
 
     remove_separator_if_next(',', remaining, pos_modes)

--- a/src/fields/parameter/parsers.rs
+++ b/src/fields/parameter/parsers.rs
@@ -103,11 +103,11 @@ pub fn parse_quality(input: &str) -> IResult<&str, Fix> {
     remove_separator_if_next(',', remaining, result)
 }
 
-pub fn parse_pos_mode_vec(input: &str) -> IResult<&str, Vec<Fix>> {
+pub fn parse_pos_mode_vec(input: &str) -> IResult<&str, FixList> {
     let (remaining, mut pos_modes_str) = take_until(",")(input)?;
     // Should actually be pos_modes_str,len() -1
     // But i dont want to deal with negative values
-    let mut pos_modes = Vec::with_capacity(pos_modes_str.len());
+    let mut pos_modes = FixList::new();
 
     while pos_modes_str.len() > 0 {
         let res = parse_pos_mode(pos_modes_str)?;

--- a/src/fields/parameter/structs.rs
+++ b/src/fields/parameter/structs.rs
@@ -1,3 +1,5 @@
+use arrayvec::ArrayVec;
+
 #[derive(Debug, PartialEq)]
 /// GPS quality indicator
 pub enum Fix {
@@ -14,6 +16,9 @@ pub enum Fix {
     /// U-BLOX dead reckoning fix
     EstimatedOrDeadReckoningFix,
 }
+
+/// List of [Fix]. Maximum of 4 as per GNS definition.
+pub type FixList = ArrayVec<[Fix; 4]>;
 
 #[derive(Debug, PartialEq)]
 /// Defines if the provided data is valid or not.

--- a/src/fields/time/parsers.rs
+++ b/src/fields/time/parsers.rs
@@ -31,9 +31,9 @@ pub fn parse_time(input: &str) -> IResult<&str, Option<NaiveTime>> {
     }
     let (remaining, time_str) = parse_string(input)?;
 
-    let splitted: Vec<&str> = time_str.split('.').collect();
+    let mut split = time_str.split('.');
 
-    let maybe_time = match (splitted.get(0), splitted.get(1)) {
+    let maybe_time = match (split.next(), split.next()) {
         (Some(hms), Some(milis)) => {
             if let Ok(raw_hms) = str::parse::<u32>(hms) {
                 let hours = raw_hms / 10_000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 extern crate chrono;
 extern crate nom;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use crate::error::Error;
 pub mod error;
 pub mod fields;
 pub mod messages;
-mod parser_utils;
+pub mod parser_utils;
 pub mod sentence;
 
 pub use sentence::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 extern crate chrono;
 extern crate nom;

--- a/src/messages/gns.rs
+++ b/src/messages/gns.rs
@@ -21,7 +21,7 @@ pub struct GNSMessage {
     /// East/West indicator
     pub ew: Option<EastWest>,
     /// Positioning mode,
-    pub pos_mode: Vec<Fix>,
+    pub pos_mode: FixList,
     /// Number of satellites used
     pub num_sv: Option<u8>,
     /// Horizontal Dilution of Precision
@@ -106,7 +106,12 @@ mod tests {
                 ns: Some(NorthSouth::North),
                 lon: Some(Degree(0.12293799999999999)), // floats ¯\_(ツ)_/¯
                 ew: Some(EastWest::West),
-                pos_mode: vec![Fix::AutonomousGNSSFix, Fix::NoFix, Fix::NoFix, Fix::NoFix],
+                pos_mode: FixList::from([
+                    Fix::AutonomousGNSSFix,
+                    Fix::NoFix,
+                    Fix::NoFix,
+                    Fix::NoFix,
+                ]),
                 num_sv: Some(7),
                 hdop: Some(1.18),
                 alt: Some(Meter(111.5)),

--- a/src/messages/gsv.rs
+++ b/src/messages/gsv.rs
@@ -14,7 +14,7 @@ pub struct GSVMessage {
     /// both the talker ID and the signalId
     pub satellite_num: u8,
     /// Satellites in view
-    pub satellites: Vec<SatelliteInView>,
+    pub satellites: SatelliteInViewList,
 }
 
 pub fn parse_gsv(input: &str) -> IResult<&str, GSVMessage> {
@@ -49,7 +49,7 @@ mod tests {
                 total_msgs: 3,
                 msg_num: 1,
                 satellite_num: 11,
-                satellites: vec![
+                satellites: SatelliteInViewList::from([
                     SatelliteInView {
                         id: Some(3),
                         elv: Some(Degree(3.)),
@@ -74,7 +74,7 @@ mod tests {
                         az: Some(Degree(292.)),
                         cno: Some(DBHZ(0.)),
                     },
-                ],
+                ]),
             },
         ));
 

--- a/src/sentence/mod.rs
+++ b/src/sentence/mod.rs
@@ -12,7 +12,6 @@ mod sentence_tests {
     use crate::fields::parameter::*;
     use crate::fields::speed::*;
     use crate::messages::*;
-
     use chrono::naive::{NaiveDate, NaiveTime};
 
     #[test]
@@ -163,7 +162,7 @@ mod sentence_tests {
                 total_msgs: 3,
                 msg_num: 1,
                 satellite_num: 11,
-                satellites: vec![
+                satellites: SatelliteInViewList::from([
                     SatelliteInView {
                         id: Some(3),
                         elv: Some(Degree(3.)),
@@ -188,7 +187,7 @@ mod sentence_tests {
                         az: Some(Degree(292.)),
                         cno: Some(DBHZ(0.)),
                     },
-                ],
+                ]),
             }),
         };
 
@@ -340,7 +339,12 @@ mod sentence_tests {
                 ns: Some(NorthSouth::North),
                 lon: Some(Degree(0.12293799999999999)), // floats ¯\_(ツ)_/¯
                 ew: Some(EastWest::West),
-                pos_mode: vec![Fix::AutonomousGNSSFix, Fix::NoFix, Fix::NoFix, Fix::NoFix],
+                pos_mode: FixList::from([
+                    Fix::AutonomousGNSSFix,
+                    Fix::NoFix,
+                    Fix::NoFix,
+                    Fix::NoFix,
+                ]),
                 num_sv: Some(7),
                 hdop: Some(1.18),
                 alt: Some(Meter(111.5)),


### PR DESCRIPTION
This makes `std` optional and allows crate to be used in embedded applications.

Everything is quite straightforward, but there are some caveats:
- `Vec` is not available in `no_std` and it was used for `Vec<Fix>` in GNS and `Vec<SatelliteInView>` in GSV. However, NMEA spec says that both of these vectors are limited to 4 entries max. So it should be safe to replace them with static sized `ArrayVec`. There could be a problem with receivers that do not respect specification though.
- I made `std` a feature, but maybe it does not need to exist at all and crate could be pure `no_std`? The only downside I see is if you use `nom` or `chrono` with `std` somewhere else they would get compiled multiple times.

I'm leaving this as a draft for now, as I have yet to test it on STM32 with Applanix GNSS.